### PR TITLE
Remove duplicate word in draco barrage description

### DIFF
--- a/data/moves/attack_descriptions.string
+++ b/data/moves/attack_descriptions.string
@@ -1244,7 +1244,7 @@ The user attacks\nwith water bubbles\nthat drains half the\ndamage it inflicted.
 The user attacks\nwith a swift slash\nthat becomes strong-\ner the faster the\nuser is.
 
 #org @DESC_DRACO_BARRAGE
-This attack beats\nbeats fairy immunities\nbut hurts the user.\nChanges split based\noff which is stronger.
+This attack beats\nfairy immunities\nbut hurts the user.\nChanges split based\noff which is stronger.
 
 #org @DESC_STONE_AXE
 The user swings\nwith an axe that\nhas a high-crit ratio\nand sets Stealth\nRocks.


### PR DESCRIPTION
The description currently appears as: `This attack beats beats fairy immunities but hurts the user. Changes split based off which is stronger.`
![image](https://github.com/ydarissep/Radical-Red-Pokedex/assets/20605679/efcd3e34-2fdd-4f83-8dc8-0ee26d8fcfd6)
With "beats" repeated, which doesn't seem correct.